### PR TITLE
fix: 修复新回复耗时与完成时间丢失

### DIFF
--- a/ui/lib/features/home/pages/chat/services/chat_runtime_snapshot_support.dart
+++ b/ui/lib/features/home/pages/chat/services/chat_runtime_snapshot_support.dart
@@ -74,6 +74,15 @@ extension ChatRuntimeSnapshotSupport on ChatConversationRuntimeCoordinator {
     });
     final snapshotHasLiveWork =
         isAiResponding || isCheckingExecutableTask || isExecutingTask;
+    // Page dispatch snapshots may refresh the same admitted prompt before
+    // session/prompt starts. Its clock belongs to admission/completion, not
+    // to the item projection buffers cleared below.
+    final preservedPromptTimingKey =
+        hasBoundLiveTask &&
+            currentDispatchTurnId != null &&
+            currentDispatchTurnId == runtime.currentDispatchTurnId
+        ? 'prompt:$currentDispatchTurnId'
+        : null;
     if (hasBoundLiveTask && !snapshotHasLiveWork) {
       // A history/poll snapshot has no turn identity. Once this runtime has
       // admitted a new logical turn, an idle snapshot is necessarily older or
@@ -167,7 +176,9 @@ extension ChatRuntimeSnapshotSupport on ChatConversationRuntimeCoordinator {
     runtime.browserSessionSnapshot = browserSessionSnapshot;
     runtime._streamingTextBatches.clear();
     runtime.agentEntrySequences.clear();
-    runtime.agentEntryStartTimes.clear();
+    runtime.agentEntryStartTimes.removeWhere(
+      (key, _) => key != preservedPromptTimingKey,
+    );
     _pruneAgentReplayDeltaOffsets(runtime, normalizedMessages);
     runtime.agentNextEntrySequence = 0;
     notifyListeners();

--- a/ui/test/features/home/pages/chat/chat_conversation_runtime_coordinator_test.dart
+++ b/ui/test/features/home/pages/chat/chat_conversation_runtime_coordinator_test.dart
@@ -1676,6 +1676,75 @@ void main() {
   );
 
   test(
+    'page dispatch snapshot preserves prompt timing through history commit',
+    () async {
+      const conversationId = 2211;
+      const turnId = 'page-dispatch-timing';
+      coordinator.beginAcpTurn(
+        taskId: turnId,
+        conversationId: conversationId,
+        mode: kChatRuntimeModeAgent,
+      );
+      final runtime = coordinator.runtimeFor(
+        conversationId: conversationId,
+        mode: kChatRuntimeModeAgent,
+      )!;
+      // Match _sendAgentMessage: admission, page snapshots, ACP output, response.
+      // Do not seed the start timestamp: exercise the production admission owner.
+      final startedAt = runtime.agentEntryStartTimes['prompt:$turnId'];
+      expect(startedAt, isA<int>());
+      runtime.agentEntryStartTimes['previous-item'] = 1;
+      for (var refresh = 0; refresh < 2; refresh++) {
+        coordinator.replaceConversationSnapshot(
+          conversationId: conversationId,
+          mode: kChatRuntimeModeAgent,
+          messages: [ChatMessageModel.userMessage('时间回归测试')],
+          isAiResponding: runtime.isAiResponding,
+          currentDispatchTurnId: runtime.currentDispatchTurnId,
+          lastAgentTurnId: runtime.lastAgentTurnId,
+        );
+        expect(runtime.agentEntryStartTimes, {'prompt:$turnId': startedAt});
+      }
+      applyAcp(
+        conversationId,
+        'session/update',
+        turnId: turnId,
+        params: {
+          'update': {
+            'sessionUpdate': 'agent_message_chunk',
+            'content': {'type': 'text', 'text': '测试完成'},
+          },
+        },
+      );
+      completePrompt(conversationId, turnId: turnId);
+      final reply = runtime.messages.singleWhere(
+        (m) => m.type == 1 && m.user == 2,
+      );
+      expect(reply.turnUsage?['endedAt'], isA<int>());
+      expect(reply.turnUsage?['durationMs'], isNonNegative);
+      expect(
+        runtime.agentEntryStartTimes.containsKey('prompt:$turnId'),
+        isFalse,
+      );
+      await coordinator.flushPendingPersistence(
+        conversationId: conversationId,
+        mode: kChatRuntimeModeAgent,
+      );
+      final committed = recordedMethodCalls.lastWhere(
+        (call) => call.method == 'replaceConversationMessages',
+      );
+      final messages = committed.arguments['messages'] as List;
+      final saved = messages.cast<Map>().singleWhere(
+        (m) => m['id'] == reply.id,
+      );
+      expect(
+        ChatMessageModel.fromJson(Map<String, dynamic>.from(saved)).turnUsage,
+        reply.turnUsage,
+      );
+    },
+  );
+
+  test(
     'prompt timing belongs to the final visible reply in a multi-message turn',
     () {
       const conversationId = 2210;


### PR DESCRIPTION
0.6.1 新回复缺少耗时与完成时间：页面先调用 `beginAcpTurn` 记录开始时间，随后发送前的 `replaceConversationSnapshot` 清空了同一个 `agentEntryStartTimes`。完成处理拿不到开始时间，因此两项数据都未写入回复。

在现有快照同步中，仅保留同一已登记请求的开始时间，继续清理旧的条目计时数据；仍由原有 ACP PromptResponse 完成处理生成并保存末尾信息。

验证：
- 新增真实页面调用顺序回归：请求登记 → 连续页面快照 → ACP 输出 → PromptResponse → 历史提交。修复前 endedAt 为 null，修复后通过；不手动注入请求时间。
- 独立工作树 324 项相关 Flutter 测试通过，包括 reducer、coordinator、消息列表及时间展示。
- 静态分析有 9 条现存警告（extension 中 notifyListeners 和未使用测试助手），无新增诊断。
- 真机当前未连接 ADB，尚未完成安装与设备验收；独立工作树 debug APK 构建成功（1m46s）。

此补丁不覆盖已发布的 v0.6.1 标签；不混入其他 Harness 修改。
