### PR TITLE
fix(build): 补齐 0.6.2 干净检出缺失的源码与测试

### DIFF
--- a/app/src/main/java/cn/com/omnimind/bot/agent/runtime/SubagentToolCatalogView.kt
+++ b/app/src/main/java/cn/com/omnimind/bot/agent/runtime/SubagentToolCatalogView.kt
@@ -1,0 +1,58 @@
+package cn.com.omnimind.bot.agent
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/** Enforces specialist permissions at the existing pre-execution validation boundary. */
+internal class SubagentToolCatalogView(
+    private val parent: AgentToolCatalog,
+    private val profileId: String,
+) : AgentToolCatalog {
+    private val readable = mapOf(
+        "file_read" to "workspace", "file_list" to "workspace",
+        "file_search" to "workspace", "file_stat" to "workspace",
+        "memory_search" to "memory", "memory_load" to "memory",
+        "skills_list" to "skill", "skills_read" to "skill",
+        "context_apps_query" to "builtin", "context_time_now" to "builtin",
+        "browser_use" to "browser",
+    )
+    private val memoryTools = mapOf(
+        "memory_write_daily" to "memory", "memory_upsert_longterm" to "memory",
+        "memory_rollup_day" to "memory",
+    )
+    private fun allowed(name: String): Boolean {
+        val expectedType = when (profileId) {
+            "explorer" -> readable[name]
+            "memory-curator" -> (readable.filterValues { it == "workspace" || it == "memory" } + memoryTools)[name]
+            else -> null
+        } ?: return false
+        val descriptor = parent.runtimeDescriptor(name)
+        return descriptor.toolType == expectedType && descriptor.serverName == null &&
+            parent.toolsForModel.any { it.function.name == name }
+    }
+
+    override val toolsForModel: List<ChatCompletionTool>
+        get() = parent.toolsForModel.filter { allowed(it.function.name) }
+
+    // Metadata is needed to project rejected calls and pair their error results.
+    override fun runtimeDescriptor(toolName: String) = parent.runtimeDescriptor(toolName)
+
+    override fun validateArguments(toolName: String, arguments: JsonObject) {
+        require(allowed(toolName)) { "Tool '$toolName' is outside the $profileId role permissions" }
+        if (profileId == "explorer" && toolName == "browser_use") {
+            val action = arguments["action"]?.jsonPrimitive?.contentOrNull
+            require(action in setOf("navigate", "screenshot", "get_text", "get_page_info",
+                "find_elements", "get_readable", "get_backbone", "list_tabs", "scroll",
+                "go_back", "go_forward", "wait_for_selector")) {
+                "Browser action '$action' is outside explorer observation permissions"
+            }
+        }
+        parent.validateArguments(toolName, arguments)
+    }
+
+    override fun searchTools(query: String, limit: Int?): List<AgentToolSearchEntry> =
+        parent.searchTools(query, null).filter { allowed(it.name) }.let { matches ->
+            if (limit == null) matches else matches.take(limit.coerceAtLeast(0))
+        }
+}

--- a/app/src/test/java/cn/com/omnimind/bot/agent/runtime/AcpTurnLifecycleRegressionTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/runtime/AcpTurnLifecycleRegressionTest.kt
@@ -1,0 +1,69 @@
+package cn.com.omnimind.bot.agent.runtime
+
+import kotlinx.coroutines.Job
+import org.junit.Assert.*
+import org.junit.Test
+
+class AcpTurnLifecycleRegressionTest {
+    @Test
+    fun `success error and cancellation release same session for the next message`() {
+        val owner = AcpTurnOwnershipRegistry()
+        listOf("end_turn", "error", "cancelled").forEachIndexed { index, status ->
+            val turn = "turn-$index"
+            assertTrue(owner.reserve("session", turn, "request-$index") is AcpTurnReservation.Started)
+            assertNotNull(owner.finish("session", turn, status))
+            assertFalse(owner.hasActiveTurns())
+        }
+        assertTrue(owner.reserve("session", "next", "next-request") is AcpTurnReservation.Started)
+    }
+
+    @Test
+    fun `duplicate sends and late completion cannot replay or release a newer turn`() {
+        val owner = AcpTurnOwnershipRegistry()
+        owner.reserve("session", "first", "request-1")
+        val duplicate = owner.reserve("session", "incorrect-new-id", "request-1")
+        assertEquals("first", (duplicate as AcpTurnReservation.InFlight).record.turnId)
+        assertTrue(owner.reserve("session", "second", "request-2") is AcpTurnReservation.Busy)
+        owner.finish("session", "first", "end_turn")
+        assertTrue(owner.reserve("session", "second", "request-2") is AcpTurnReservation.Started)
+        assertNull(owner.finish("session", "first", "error"))
+        assertEquals("second", owner.activeTurnId("session"))
+        assertTrue(owner.reserve("session", "third", "request-1") is AcpTurnReservation.Completed)
+    }
+
+    @Test
+    fun `disconnect releases only its transport scope and retains duplicate protection`() {
+        val store = AcpTurnOwnershipStore()
+        val local = AcpTurnOwnershipRegistry(store, "local")
+        val remote = AcpTurnOwnershipRegistry(store, "remote")
+        local.reserve("same-id", "local-turn", "request")
+        remote.reserve("same-id", "remote-turn", "request")
+        assertEquals(1, local.finishAll("error").size)
+        assertEquals("remote-turn", remote.activeTurnId("same-id"))
+        assertTrue(local.reserve("same-id", "retry", "request") is AcpTurnReservation.Completed)
+        assertTrue(local.reserve("same-id", "new-turn", "new-request") is AcpTurnReservation.Started)
+    }
+
+    @Test
+    fun `cancellation before prompt prevents sending but after admission delegates to ACP`() {
+        val preparation = Job()
+        val before = AcpPromptExecution(preparation)
+        assertFalse(before.requestCancellation())
+        assertTrue(preparation.isCancelled)
+        val prompt = Job()
+        before.attachPromptJob(prompt)
+        assertTrue(prompt.isCancelled)
+        assertFalse(before.tryStartPrompt())
+
+        val activePreparation = Job()
+        val activePrompt = Job()
+        val after = AcpPromptExecution(activePreparation)
+        after.attachPromptJob(activePrompt)
+        assertTrue(after.tryStartPrompt())
+        assertTrue(after.requestCancellation())
+        assertFalse(activePrompt.isCancelled)
+        assertFalse(activePreparation.isCancelled)
+        activePrompt.cancel()
+        activePreparation.cancel()
+    }
+}

--- a/app/src/test/java/cn/com/omnimind/bot/agent/runtime/AgentAdapterCatalogTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/runtime/AgentAdapterCatalogTest.kt
@@ -1,0 +1,104 @@
+package cn.com.omnimind.bot.agent.runtime
+
+import cn.com.omnimind.baselib.llm.ProviderModelOption
+import com.google.gson.JsonParser
+import java.io.File
+import org.junit.Assert.*
+import org.junit.Test
+
+/** Exercise the actual shipped catalog, so a new profile cannot bypass mapping coverage. */
+class AgentAdapterCatalogTest {
+    @Test
+    fun everyShippedHarnessHasAnExplicitConfigurationOwner() {
+        val profiles = AcpAgentCatalog.parse(File("src/main/assets/acp/agents.json").readText()) {
+            File("src/main/assets/$it").readText()
+        }.agents
+        assertEquals(6, profiles.size)
+        for (profile in profiles) {
+            val runtime = requireNotNull(AcpAgentProfileStore.officialRuntime(profile))
+            val adapter = runtime.harnessAdapter
+            if (profile.id == AcpAgentProfileStore.XIAOWAN_AGENT_ID) {
+                assertNull(adapter.configAdapterId) // In-process Provider execution, no deployment file.
+                continue
+            }
+            assertNotNull(profile.id, adapter.configAdapterId)
+            for ((protocol, wire) in listOf(
+                "openai_compatible" to "chat_completions",
+                "openai_compatible" to "responses",
+                "anthropic" to "chat_completions",
+            )) {
+                val input = AgentProviderMappingInput(
+                    agentId = profile.id, harnessAdapter = adapter,
+                    provider = AgentProviderCredentials("https://fixture.invalid/v1", "fixture-key",
+                        protocolType = protocol, wireApi = wire), model = "org/test-model",
+                )
+                // Claude selects the Anthropic wire itself; a shared gateway
+                // may expose it even when its saved default is OpenAI-compatible.
+                val incompatible = adapter.configAdapterId == "codex" && protocol == "anthropic"
+                if (incompatible) {
+                    val failure = runCatching { AgentConfigAdapterRegistry.map(input) }.exceptionOrNull()
+                    assertTrue("${profile.id}/$protocol must reject incompatible configuration", failure is IllegalArgumentException)
+                    continue
+                }
+                val mapping = AgentConfigAdapterRegistry.map(input)
+                val catalog = listOf(ProviderModelOption(id = "org/test-model"), ProviderModelOption(id = "org/second-model"))
+                val files = AgentConfigAdapterRegistry.launchConfigWrites(input, mapping, catalog, "{}")
+                val refreshFiles = AgentConfigAdapterRegistry.launchConfigWrites(input, mapping,
+                    catalog + ProviderModelOption(id = "org/new-model"), "{}")
+                val evidence = File("build/reports/harness-adapters/${adapter.configAdapterId}-$protocol-$wire.json")
+                evidence.parentFile.mkdirs()
+                evidence.writeText(com.google.gson.Gson().toJson(mapOf(
+                    "harness" to adapter.configAdapterId, "protocol" to protocol, "wire" to wire,
+                    "environment" to mapping.environment, "files" to files, "refreshFiles" to refreshFiles,
+                    "clientCapabilityMeta" to com.google.gson.Gson().fromJson(
+                        input.harnessAdapter.clientCapabilityMeta(kotlinx.serialization.json.buildJsonObject {}).toString(),
+                        Map::class.java,
+                    ),
+                )))
+                assertTrue("${profile.id} dropped selected model",
+                    mapping.environment.values.any { it == "org/test-model" } ||
+                        files.any { it.content.contains("org/test-model") })
+                when (adapter.configAdapterId) {
+                    "open-code" -> {
+                        val sdk = JsonParser.parseString(files.single().content).asJsonObject
+                            .getAsJsonObject("provider").getAsJsonObject("omnibot")["npm"].asString
+                        assertEquals(when {
+                            protocol == "anthropic" -> "@ai-sdk/anthropic"
+                            wire == "responses" -> "@ai-sdk/openai"
+                            else -> "@ai-sdk/openai-compatible"
+                        }, sdk)
+                    }
+                    "kimi-code" -> {
+                        val type = when {
+                            protocol == "anthropic" -> "anthropic"
+                            wire == "responses" -> "openai_responses"
+                            else -> "openai"
+                        }
+                        assertTrue(files.single().content.contains("type = \"$type\""))
+                        assertFalse(mapping.environment.containsKey("KIMI_MODEL_NAME"))
+                    }
+                    "claude-code" -> assertEquals("fixture-key", mapping.environment["ANTHROPIC_API_KEY"])
+                    "codex" -> assertEquals("responses", mapping.codexWireApi)
+                    "deepseek-harness" -> assertTrue(files.single().content.contains(when {
+                        protocol == "anthropic" -> "anthropic-messages"
+                        wire == "responses" -> "openai-responses"
+                        else -> "openai-completions"
+                    }))
+                    else -> fail("Add assertions for new adapter ${adapter.configAdapterId}")
+                }
+            }
+        }
+    }
+
+    @Test
+    fun unknownAdapterFailsClearlyInsteadOfLaunchingWithEmptyConfiguration() {
+        val adapter = object : AcpHarnessAdapter { override val configAdapterId = "missing-adapter" }
+        val failure = runCatching {
+            AgentConfigAdapterRegistry.map(AgentProviderMappingInput("custom", null, null, adapter))
+        }.exceptionOrNull()
+        assertTrue(failure is IllegalArgumentException)
+        assertTrue(failure!!.message!!.contains("missing-adapter"))
+        assertEquals(emptyMap<String, String>(), AgentConfigAdapterRegistry.map(
+            AgentProviderMappingInput("custom", null, null, AcpHarnessAdapters.standard)).environment)
+    }
+}

--- a/app/src/test/java/cn/com/omnimind/bot/agent/runtime/LocalAcpRuntimeInitializationTest.kt
+++ b/app/src/test/java/cn/com/omnimind/bot/agent/runtime/LocalAcpRuntimeInitializationTest.kt
@@ -1,0 +1,147 @@
+package cn.com.omnimind.bot.agent.runtime
+
+import cn.com.omnimind.bot.agent.AgentScheduleToolBridge
+import cn.com.omnimind.bot.agent.AgentWorkspaceManager
+import com.agentclientprotocol.transport.StdioTransport
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.mockito.Mockito.doAnswer
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.mockConstruction
+import org.mockito.Mockito.`when`
+import kotlin.coroutines.Continuation
+
+class LocalAcpRuntimeInitializationTest {
+    @get:Rule val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun `command notification waits for session initialization without creating a turn`() = runBlocking {
+        val context = acpProfileStoreTestContext(temporaryFolder.root)
+        val store = AcpAgentProfileStore(context)
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val delivered = mutableListOf<Map<String, Any?>>()
+        val forwarded = CompletableDeferred<Unit>()
+        val runtime = LocalAcpRuntime(
+            context, scope, mock(AgentSessionBindingRepository::class.java), store,
+            prepareLaunchEnvironment = { emptyMap() },
+            buildHandoffContext = { _, _ -> null },
+            scheduleToolBridge = mock(AgentScheduleToolBridge::class.java),
+            onMessage = { delivered += it; forwarded.complete(Unit) },
+        )
+        val lock = runtime.javaClass.getDeclaredField("sessionMutex").run {
+            isAccessible = true
+            get(runtime) as kotlinx.coroutines.sync.Mutex
+        }
+        val factory = runtime.javaClass.getDeclaredMethod("operationsFactory").run {
+            isAccessible = true
+            invoke(runtime) as com.agentclientprotocol.client.ClientOperationsFactory
+        }
+        val operations = factory.createClientOperations(
+            com.agentclientprotocol.model.SessionId("bound-session"),
+            mock(com.agentclientprotocol.model.AcpCreatedSessionResponse::class.java),
+        )
+        try {
+            lock.lock()
+            val notifying = launch(start = CoroutineStart.UNDISPATCHED) {
+                operations.notify(com.agentclientprotocol.model.SessionUpdate.AvailableCommandsUpdate(
+                    listOf(com.agentclientprotocol.model.AvailableCommand("compact", "Compact context")),
+                ), null)
+            }
+            assertTrue(delivered.isEmpty())
+            assertTrue("The SDK receive loop must remain free to read session/new", notifying.isCompleted)
+            lock.unlock()
+            withTimeout(5_000) { forwarded.await() }
+            assertEquals(1, delivered.size)
+            assertEquals("session/update", delivered.single()["method"])
+            assertEquals(null, delivered.single()["turnId"])
+            assertEquals(false, delivered.single()["hostTurnId"])
+        } finally {
+            if (lock.isLocked) lock.unlock()
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `cancelling a real pending initialize releases its unadopted connection`() =
+        checkCleanup(timeout = false)
+
+    @Test
+    fun `a caller timeout during initialize releases its unadopted connection`() =
+        checkCleanup(timeout = true)
+
+    private fun checkCleanup(timeout: Boolean) = runBlocking {
+        val context = acpProfileStoreTestContext(temporaryFolder.root)
+        val store = AcpAgentProfileStore(context)
+        store.select(AcpAgentProfileStore.XIAOWAN_AGENT_ID)
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+        val initializedRequest = CompletableDeferred<Unit>()
+        var closes = 0
+        var cleanupContextActive = false
+        // Only replace the platform connection. The real runtime owner,
+        // Protocol, Client.initialize, cancellation and catch path all run.
+        mockConstruction(XiaowanAcpConnection::class.java) { connection, _ ->
+            `when`(connection.exitSignal).thenReturn(CompletableDeferred())
+            `when`(connection.diagnosticSummary()).thenReturn("")
+            `when`(connection.createTransport(scope)).thenReturn(
+                StdioTransport(
+                    parentScope = scope,
+                    ioDispatcher = Dispatchers.Unconfined,
+                    input = flow { awaitCancellation() },
+                    output = { line ->
+                        check(line.contains("initialize"))
+                        initializedRequest.complete(Unit)
+                    },
+                    name = "initialize-cancellation-regression",
+                ),
+            )
+            runBlocking {
+                doAnswer { call ->
+                    closes++
+                    cleanupContextActive = (call.rawArguments.last() as Continuation<*>).context.isActive
+                    Unit
+                }.`when`(connection).close()
+            }
+        }.use {
+            val runtime = LocalAcpRuntime(
+                context, scope, mock(AgentSessionBindingRepository::class.java), store,
+                prepareLaunchEnvironment = { emptyMap() },
+                buildHandoffContext = { _, _ -> null },
+                scheduleToolBridge = mock(AgentScheduleToolBridge::class.java),
+                onMessage = { error("An initialize cancellation must not synthesize turn events") },
+            )
+            runtime.javaClass.getDeclaredField("workspaceManager").apply {
+                isAccessible = true
+                set(runtime, mock(AgentWorkspaceManager::class.java))
+            }
+            try {
+                val connecting = launch(start = CoroutineStart.UNDISPATCHED) {
+                    if (timeout) withTimeout(1_000) { runtime.connect() } else runtime.connect()
+                }
+                withTimeout(5_000) { initializedRequest.await() }
+                if (timeout) connecting.join() else connecting.cancelAndJoin()
+                assertFalse(runtime.isConnected)
+                assertEquals("Unadopted connection leaked", 1, closes)
+                assertTrue("Suspending cleanup needs a live cleanup context", cleanupContextActive)
+            } finally {
+                scope.cancel()
+            }
+        }
+    }
+}


### PR DESCRIPTION
0.6.2 干净检出时缺少 SubagentToolCatalogView，导致 SubagentDispatcher 无法编译。本机 `.git/info/exclude` 的 `runtime/` 规则漏收了该源码以及 ACP 生命周期、初始化和适配器目录测试；补齐这些现有实现与测试，使干净检出包含与本地验证相同的代码。

这次只补齐发布文件，不改变会话或权限策略。前次 CI 还出现 Kotlin 2.4/2.2 元数据版本不匹配，正在独立目录复现并以新 CI 结果核验；未绕过版本检查，未创建正式发布标签。

验证更新：独立工作区编译成功；与 CI 相同的 Gradle 单元测试和 Lint 命令成功（7m13s），964 tests、0 failures、0 errors、0 skipped。未修改 Kotlin 版本或禁用元数据检查。本机排除文件审计未发现其他漏收 Kotlin/Dart 源码。远端 CI 仍在执行。
