### PR TITLE
docs: 更新开发环境要求

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ Choose the LAN address and token mode in the terminal setup UI, then scan the pr
 
 ### Requirements
 
-- Flutter SDK `3.9.2+`
-- JDK `11+`
+- Flutter SDK `3.47.2+`
+- JDK `17+`
 - Node.js `20.19+` or `22.12+` and pnpm `10.28.0` (for WebUI development)
 
 ### Get the code

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -130,8 +130,8 @@ npx @thuocean/codex-bridge
 
 ### 环境要求
 
-- Flutter SDK `3.9.2+`
-- JDK `11+`
+- Flutter SDK `3.47.2+`
+- JDK `17+`
 - Node.js `20.19+` 或 `22.12+`、pnpm `10.28.0`（用于 WebUI 开发）
 
 ### 获取代码


### PR DESCRIPTION
## 变更摘要

同步英文和中文 README 中的开发环境要求，使其与当前项目实际声明的 SDK 和 Android 构建工具链保持一致。

本次修改同时修正原文档中的两个版本标注问题：原来的 `Flutter 3.9.2+` 与历史 Dart SDK 约束 `^3.9.2` 相同，而 Flutter 官方并不存在稳定版 `3.9.2`；原来的 JDK `11+` 也已低于当前 Gradle / Android Gradle Plugin 的运行要求。

## 变更类型

- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [x] 文档更新
- [ ] 测试相关
- [ ] CI/CD 或构建相关

## 关联 Issue

无

## 主要改动

1. 将 `README.md` 中的 Flutter SDK 要求从 `3.9.2+` 更新为 `3.47.2+`。
2. 将 `README.md` 中的 JDK 要求从 `11+` 更新为 `17+`。
3. 同步更新 `README.zh-CN.md` 中的对应内容。
4. 本 PR 仅修改文档，不涉及源代码、依赖、构建配置或运行时逻辑。

## 版本依据

这些版本来自当前项目的实际构建约束，而不是仅根据 CI 当前使用的版本推断：

- [`ui/pubspec.yaml`](https://github.com/omnimind-ai/OmniBot/blob/main/ui/pubspec.yaml#L20-L22) 当前声明 Flutter SDK `>=3.47.2`、Dart SDK `^3.13.0`。
- Dart 官方文档说明，`environment.flutter` 的下限会由 `flutter pub` 实际校验，低于该版本的 Flutter SDK 无法满足项目约束。
- Flutter 官方发布记录中没有稳定版 Flutter `3.9.2`；Dart `3.9.2` 实际随 Flutter `3.35.7` 发布。因此，原 README 中的 `Flutter 3.9.2+` 应为将 Dart 版本误标为 Flutter 版本。
- 当前项目使用 Android Gradle Plugin 9.3.2 和 Gradle 9.5。AGP 9.3 官方兼容矩阵及 Gradle 运行要求均将 JDK 17 作为最低运行版本。

参考：

- [Dart / Flutter SDK constraints](https://dart.dev/tools/pub/pubspec#flutter-sdk-constraints)
- [Android Gradle Plugin 9.3 compatibility](https://developer.android.com/build/releases/agp-9-3-0-release-notes)

## 测试说明

- [ ] 已本地编译通过（本 PR 仅修改文档；已运行 Gradle `help` 进行构建配置检查）
- [x] 已执行相关测试
- [ ] 已手动验证关键路径（本 PR 无 UI 或运行时改动）

测试细节：

### 当前工具链验证

```text
Flutter 3.47.2 / Dart 3.13.2
flutter pub get                         passed

JDK 21
gradlew.bat help --no-daemon             BUILD SUCCESSFUL

flutter analyze --no-fatal-warnings
--no-fatal-infos                         exit code 0
                                         仅包含已有诊断

git diff --check                         passed
```

完整 `flutter test` 已在 Windows 环境执行：1246 个通过，9 个失败。失败集中在当前 Windows 环境下的 CRLF、路径分隔符、符号链接权限和临时文件处理；本 PR 未修改源代码或测试文件。

### 旧文档版本兼容性检查

```text
Flutter 3.9.2
不存在对应的稳定版 Flutter SDK。
Dart 3.9.2 对应的实际稳定版 Flutter 为 3.35.7。

Flutter 3.35.7 / Dart 3.9.2
当前项目 flutter pub get 失败：
Because ui requires SDK version ^3.13.0,
version solving failed.

在隔离 Dart 约束后再次检查：
Because the project requires Flutter SDK version >=3.47.2,
version solving failed.

JDK 11
当前 Gradle 构建失败：
Gradle requires JVM 17 or later to run.
```

## UI 变更（如有）

无

## 风险与回滚

仅修改开发文档，无运行时风险。

如需回滚，恢复 `README.md` 和 `README.zh-CN.md` 中原有的版本说明即可。

## 自检清单

- [x] 文档内容已与当前 `ui/pubspec.yaml` 和构建工具链核对
- [x] 未修改无关模块
- [x] 未引入源代码或运行时变更
- [x] 英文和中文 README 已同步更新